### PR TITLE
Add macOS and Linux Support to Zig Formula with Automatic Updates

### DIFF
--- a/Formula/zig.rb
+++ b/Formula/zig.rb
@@ -3,7 +3,7 @@ class Zig < Formula
   homepage "https://ziglang.org/"
   license "MIT"
   version "0.14.0-dev.15+d4bc64038"
-  
+
   on_macos do
     if Hardware::CPU.arm?
       url "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.15+d4bc64038.tar.xz"
@@ -27,6 +27,28 @@ class Zig < Formula
     end
   end
 
+
+  on_linux do
+    if Hardware::CPU.intel?
+      url "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.15+d4bc64038.tar.xz"
+      sha256 "0e96b554aafea13dff5d62a0bdc340ecfe4c62d32c3832ea943d781e4381fd3a"
+
+      def install
+        bin.install "zig"
+        lib.install Dir["lib/*"]
+      end
+    end
+    if Hardware::CPU.arm?
+      url "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.15+d4bc64038.tar.xz"
+      sha256 "e3e0f839e7d1bc134924f4a68d317e71bc5a36e856bf09eb2fa4e6f36c5a3c3f"
+
+      def install
+        bin.install "zig"
+        lib.install Dir["lib/*"]
+      end
+    end
+  end
+
   test do
     (testpath/"hello.zig").write <<~EOS
       const std = @import("std");
@@ -38,8 +60,6 @@ class Zig < Formula
     system "#{bin}/zig", "build-exe", "hello.zig"
     assert_equal "Hello, world!", shell_output("./hello")
 
-    # error: 'TARGET_OS_IPHONE' is not defined, evaluates to 0
-    # ziglang/zig#10377
     ENV.delete "CPATH"
     (testpath/"hello.c").write <<~EOS
       #include <stdio.h>

--- a/fetch_latest.py
+++ b/fetch_latest.py
@@ -2,38 +2,57 @@ import re
 import urllib.request
 import json
 
-# https://docs.python.org/3/library/urllib.request.html#examples
-# https://docs.aws.amazon.com/general/latest/gr/aws-ip-ranges.html
 res = urllib.request.urlopen('https://ziglang.org/download/index.json')
 res_body = res.read()
 
-# https://docs.python.org/3/library/json.html
 data = json.loads(res_body.decode("utf-8"))
 
 aarch64_macos = data["master"]["aarch64-macos"]
 x86_64_macos = data["master"]["x86_64-macos"]
 
-version_match = re.search(r"macos-aarch64-(.*?)-dev\.(.*?)\.tar\.xz",aarch64_macos["tarball"])
+# Extrai informações para Linux
+aarch64_linux = data["master"]["aarch64-linux"]
+x86_64_linux = data["master"]["x86_64-linux"]
+
+version_match = re.search(r"macos-aarch64-(.*?)-dev\.(.*?)\.tar\.xz", aarch64_macos["tarball"])
 version = version_match.group(1)
 version_hash = version_match.group(2)
 
 content = open('Formula/zig.rb', "r", encoding="utf-8").read()
+
 content = re.sub(
-	r'version \".*?\"',
-	f'version \"{version}-dev.{version_hash}\"',
+    r'version \".*?\"',
+    f'version \"{version}-dev.{version_hash}\"',
     content,
     flags=re.DOTALL
 )
+
 content = re.sub(
     r'arm\?\n +url \".*?\"\n +sha256 \".*?\"',
     f'arm?\n      url \"{aarch64_macos["tarball"]}\"\n      sha256 \"{aarch64_macos["shasum"]}\"',
     content,
     flags=re.DOTALL
 )
+
 content = re.sub(
     r'intel\?\n +url \".*?\"\n +sha256 \".*?\"',
     f'intel?\n      url \"{x86_64_macos["tarball"]}\"\n      sha256 \"{x86_64_macos["shasum"]}\"',
     content,
     flags=re.DOTALL
 )
+
+content = re.sub(
+    r'arm\?\n +url \".*?\"\n +sha256 \".*?\"',
+    f'arm?\n      url \"{aarch64_linux["tarball"]}\"\n      sha256 \"{aarch64_linux["shasum"]}\"',
+    content,
+    flags=re.DOTALL
+)
+
+content = re.sub(
+    r'intel\?\n +url \".*?\"\n +sha256 \".*?\"',
+    f'intel?\n      url \"{x86_64_linux["tarball"]}\"\n      sha256 \"{x86_64_linux["shasum"]}\"',
+    content,
+    flags=re.DOTALL
+)
+
 open('Formula/zig.rb', 'w', encoding="utf-8").write(content)


### PR DESCRIPTION
This pull request updates the Homebrew formula for the Zig programming language to include support for both macOS and Linux. The formula now detects the operating system and architecture, downloading the appropriate binary and installing it correctly. Additionally, a Python script is provided to automatically update the formula with the latest version and corresponding SHA256 checksums from the Zig download page.

### Changes: 
 Linux Support:

 * Added URLs and SHA256 checksums for both ARM and Intel architectures.
 * Updated the install method to include necessary binaries and libraries for Linux.
 
Python Script for Automatic Updates:
* A script (`update_latest.py`) is provided to fetch the latest version and checksums from the Zig download page and update the formula accordingly.

The formula `zig.rb` has been updated to support installation on both macOS and Linux platforms